### PR TITLE
Fix content not being visible on the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dist
 
 # IDEs
 .vscode/
+
+# Helix stuff
+.hlx/

--- a/styles.css
+++ b/styles.css
@@ -43,7 +43,7 @@ body {
     font-family: adobe-clean, -apple-system, BlinkMacSystemFont, Segoe UI,Roboto, sans-serif;
 }
 
-.plain--theme {
+.tutorial--theme {
     opacity: 1;
 }
 


### PR DESCRIPTION
Issue: Content on https://docs--acom-kit--auniverseaway.hlx.page/tutorial is not visible
I noticed a recent commit - https://github.com/auniverseaway/acom-kit/commit/2059eb1da397079e612ccccfbafa892f736ceb68 - and it should fix this issue as well.